### PR TITLE
adding main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "enquire.js",
   "version": "2.1.0",
+  "main": "./dist/enquire.js",
   "description": "Awesome Media Queries in JavaScript",
   "homepage": "http://wicky.nillia.ms/enquire.js",
   "author": {


### PR DESCRIPTION
- without a main field neither nodejs nor browserify are able to resolve enquire
- adding the field allows me to require('enquire') in my code
