### PR TITLE
Call "unmatch" callback upon "addHandler"

### DIFF
--- a/src/MediaQuery.js
+++ b/src/MediaQuery.js
@@ -33,7 +33,7 @@
             var qh = new QueryHandler(handler);
             this.handlers.push(qh);
 
-            this.matches() && qh.on();
+            this.matches() && qh.on() || qh.off();
         },
 
         /**


### PR DESCRIPTION
Call "unmatch" callback inside "addHandler" if the query doesn't match.
