### PR TITLE
Add npm instructions to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,27 +1,33 @@
 #[enquire.js](http://wickynilliams.github.com/enquire.js/) - Awesome Media Queries in JavaScript
 
-[![Build Status](https://travis-ci.org/WickyNilliams/enquire.js.png)](https://travis-ci.org/WickyNilliams/enquire.js)
+[![Build Status](https://travis-ci.org/WickyNilliams/enquire.js.png)](https://travis-ci.org/WickyNilliams/enquire.js) [![NPM](https://img.shields.io/npm/v/enquire.js.svg)](https://www.npmjs.com/package/enquire.js)
 
 `enquire.js` is a lightweight, pure javascript library (with **no dependencies**) for programmatically responding to media queries. 
 
-##Getting enquire.js
+## Getting enquire.js
 
-###Download
+### Download
 
 Get the latest build, ready to go:
  
  * [Development](https://github.com/WickyNilliams/enquire.js/raw/master/dist/enquire.js) - unminified
  * [Production](https://github.com/WickyNilliams/enquire.js/raw/master/dist/enquire.min.js) - minified
 
-###Install via Bower
+### Install via Bower
 
-To install via the [bower](http://twitter.github.com/bower/) package repository, enter the following at the command line:
+To install via the bower package repository enter the following at the command line:
 
     bower install enquire
 
+### Install via NPM
+
+To install via the [npm](https://www.npmjs.com/package/enquire.js) package repository enter the following at the command line:
+
+    npm install --save enquire.js
+
 Easy as that :-)
 
-###Build From Source
+### Build From Source
 
 If you want build from source (and run all unit tests etc):
 
@@ -32,7 +38,7 @@ If you want build from source (and run all unit tests etc):
 
 Booya!
 
-##Quick Start
+## Quick Start
 
 The main method you will be dealing with is `register`. It's basic signature is as follows:
 
@@ -68,7 +74,7 @@ enquire.register("screen and (max-width:1000px)", {
 
 This should be enough to get you going, but **please read the full [enquire.js documentation](http://wickynilliams.github.com/enquire.js/)** if you wish to learn about the other cool features.
 
-##Contributing
+## Contributing
 
 * Got an awesome idea? 
 * Found a *not-so*-awesome bug? 
@@ -78,7 +84,7 @@ Then please don't hesitate to raise an issue, they will *all* be looked at and t
 
 And for all the cool cats who are prepared to give their time to contribute code, feel free to open a pull request. If you could write unit tests to accompany your pull request that would be pretty sweet, but no worries if not - if it's good enough to be merged in, it's good enough for me to spend a little time to write tests on your behalf :-)
 
-##License
+## License
 
 License: MIT (http://www.opensource.org/licenses/mit-license.php)
 


### PR DESCRIPTION
Enquire can't be found on NPM easily because another package comes up in Google first. Adding the reference to the right package will stop issues like #136 being reported.
