### PR TITLE
Fallback to native MS prefixed matchMedia

### DIFF
--- a/src/include/wrap.js
+++ b/src/include/wrap.js
@@ -1,5 +1,5 @@
 ;(function (name, context, factory) {
-	var matchMedia = window.matchMedia;
+	var matchMedia = window.matchMedia || window.msMatchMedia;
 
 	if (typeof module !== 'undefined' && module.exports) {
 		module.exports = factory(matchMedia);


### PR DESCRIPTION
Fallback to native MS- prefixed implementation of matchMedia() if possible. 

Otherwise it doesn't work well with Modernizr:
`Modernizr.matchmedia` checks if prefixed version exists and thus returns true, while `window.matchMedia` is not there.

Also see https://github.com/Modernizr/Modernizr/commit/b9cc2d40725f9aac01412c74be6f83ec415a2734
