### PR TITLE
Solve matchMedia not present, legacy browsers require a polyfill issue

### DIFF
--- a/src/include/wrap.js
+++ b/src/include/wrap.js
@@ -1,4 +1,16 @@
 ;(function (name, context, factory) {
+	if (typeof window !== 'undefined') {
+	    var matchMediaPolyfill = function matchMediaPolyfill(mediaQuery) {
+	      return {
+		media: mediaQuery,
+		matches: false,
+		addListener: function addListener() {},
+		removeListener: function removeListener() {}
+	      };
+	    };
+	    window.matchMedia = window.matchMedia || matchMediaPolyfill;
+	}
+	
 	var matchMedia = window.matchMedia;
 
 	if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
Including it into the file other dependencies will not to have issues when run tests.
