### PR TITLE
feat: Support SSR

### DIFF
--- a/src/MediaQueryDispatch.js
+++ b/src/MediaQueryDispatch.js
@@ -11,6 +11,11 @@ var isArray = Util.isArray;
  * @constructor
  */
 function MediaQueryDispatch () {
+    // Support SSR
+    if (typeof window === 'undefined') {
+        return;
+    }
+
     if(!window.matchMedia) {
         throw new Error('matchMedia not present, legacy browsers require a polyfill');
     }


### PR DESCRIPTION
@viljamis 
When I use enquire.js in a Vite project, the following error was reported when building production package:

```
✓ building client + server bundles...
✖ rendering pages...
build error:
 ReferenceError: window is not defined
```

I found that the reason for the error was that the MediaQueryDispatch method in the mediaquerydispatch.js file don't make judgments about the client environment.

When in the SSR situation, the code is running in nodeJS environment, no window variables, so the error will be reported.

I fixed the issue by adding
```js
if (typeof window === 'undefined') {
  return;
}
```

It works well, please merge this PR and release a new version.

Thanks! Best wishs for you!